### PR TITLE
Removing misleading statements on relationship to Basis module

### DIFF
--- a/ImplementationGuide/markdown/CapabilityStatement.md
+++ b/ImplementationGuide/markdown/CapabilityStatement.md
@@ -15,12 +15,6 @@ Die Verwendung der [CapabilityStatement-Expectation](https://hl7.org/fhir/R4/ext
 
 ## CapabilityStatement (Requirement) ISiK-Vitalparameter
 
-Die Bereitstellung des CapabilityStatments für das Modul "Vitalparameter" erfolgt zusammen mit der Festlegung der bestätigungsrelevanten Systeme in Stufe 2.
-
-Für Systeme, die das Modul "Vitalparameter" implementieren, ist außerdem die Erfüllung der Mindestanforderungen des [Moduls "Basis"](https://simplifier.net/guide/Implementierungsleitfaden-ISiK-Basismodul-Stufe-3/ImplementationGuide-markdown-Einfuehrung?version=current) erforderlich:
-
-Canonical: https://gematik.de/fhir/isik/v3/VitalparameterUndKoerpermasze/CapabilityStatement/core-server
-
 [Link Simplifier Profil Übersicht](https://simplifier.net/isik-vitalparameter-und-koerpermasze-v3/isik-capabilitystatement-vitalparameter-server)
 
 {{render:https://gematik.de/fhir/isik/v3/VitalparameterUndKoerpermasze/CapabilityStatement/vitalparameter-server}}


### PR DESCRIPTION
Der gelöschte Text ist irreführend, da festgelegt wurde, dass das Basismodul nur bei Referenzen zu Patient und Encounter von Relevanz ist. Außerdem scheint die Canonical-Angabe falsch zu sein und im Text ist noch die Rede von Stufe **2** statt 3